### PR TITLE
feat: Add JarUrl#Fabric

### DIFF
--- a/plugin-build/plugin/src/main/java/dev/s7a/gradle/minecraft/server/tasks/LaunchMinecraftServerTask.kt
+++ b/plugin-build/plugin/src/main/java/dev/s7a/gradle/minecraft/server/tasks/LaunchMinecraftServerTask.kt
@@ -151,7 +151,6 @@ abstract class LaunchMinecraftServerTask : DefaultTask() {
      */
     object JarUrl {
         private val json = Json { ignoreUnknownKeys = true }
-        private const val fabricApiUrl = "https://meta.fabricmc.net/v2"
 
         @Serializable
         private data class Version(val builds: List<Int>)
@@ -239,7 +238,7 @@ abstract class LaunchMinecraftServerTask : DefaultTask() {
          */
         @Suppress("FunctionName")
         fun Fabric(minecraftVersion: String, loaderVersion: String): String {
-            val installerVersionsUrl = "$fabricApiUrl/versions/installer"
+            val installerVersionsUrl = "https://meta.fabricmc.net/v2/versions/installer"
             val installerVersionsJson = URL(installerVersionsUrl).readText()
             val latestInstallerVersion =
                 json.decodeFromString<List<FabricInstallerVersion>>(installerVersionsJson).filter { it.stable }
@@ -266,7 +265,7 @@ abstract class LaunchMinecraftServerTask : DefaultTask() {
          */
         @Suppress("FunctionName")
         fun Fabric(minecraftVersion: String): String {
-            val loaderVersionsUrl = "$fabricApiUrl/versions/loader"
+            val loaderVersionsUrl = "https://meta.fabricmc.net/v2/versions/loader"
             val loaderVersionsJson = URL(loaderVersionsUrl).readText()
             val latestLoaderVersion =
                 json.decodeFromString<List<FabricLoaderVersion>>(loaderVersionsJson).filter { it.stable }.sortedWith(

--- a/plugin-build/plugin/src/main/java/dev/s7a/gradle/minecraft/server/tasks/LaunchMinecraftServerTask.kt
+++ b/plugin-build/plugin/src/main/java/dev/s7a/gradle/minecraft/server/tasks/LaunchMinecraftServerTask.kt
@@ -238,6 +238,7 @@ abstract class LaunchMinecraftServerTask : DefaultTask() {
          */
         @Suppress("FunctionName")
         fun Fabric(minecraftVersion: String, loaderVersion: String): String {
+            val loaderVersionsUrl = "https://meta.fabricmc.net/v2/versions/loader"
             val installerVersionsUrl = "https://meta.fabricmc.net/v2/versions/installer"
             val installerVersionsJson = URL(installerVersionsUrl).readText()
             val latestInstallerVersion =
@@ -250,7 +251,7 @@ abstract class LaunchMinecraftServerTask : DefaultTask() {
                         )
                     ).asReversed()[0].version
 
-            return "$fabricApiUrl/versions/loader/$minecraftVersion/$loaderVersion/$latestInstallerVersion/server/jar"
+            return "$loaderVersionsUrl/$minecraftVersion/$loaderVersion/$latestInstallerVersion/server/jar"
         }
 
         /**


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
I've added a method for building a `JarUrl` for the [FabricMC](https://fabricmc.net) modding framework. The new `JarUrl.Fabric` methods use Fabric's API found at https://meta.fabricmc.net/ to fetch relevant version information an build a download URL from that.

It is important to note here, that the Fabric offers users to choose the game version as well as the internal mod loader version. That is why there are two new methods, one which automatically fetches the latest loader version and one which allows the user to choose the exact loader version to use. 

## 📄 Motivation and Context
While it would be possible to just copy and paste the link to the download and set it as the `jarUrl` manually, it is much more convenient to just use `JarUrl.Fabric("1.19.2")` and have the Gradle plugin work out the latest version to download.

Since I am currently building a multi-platform mod for Paper and Fabric, this makes testing it much easier.

## 🧪 How Has This Been Tested?
I have altered the example mod to use `JarUrl.Fabric("1.19.2")` and `JarUrl.Fabric("1.19.2", "0.14.11")` instead of `JarUrl.Paper("1.19.2")`. Both worked flawlessly.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.